### PR TITLE
RET-5542 Unpin Android sdk and switch to AAR

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'com.apptimize:apptimize-android:3.7.18+'
+        implementation 'com.apptimize:apptimize-android:[3.10,4.0)@aar'
     }
 }

--- a/android/src/main/java/com/apptimize/apptimize_flutter/ApptimizeFlutterPlugin.java
+++ b/android/src/main/java/com/apptimize/apptimize_flutter/ApptimizeFlutterPlugin.java
@@ -227,7 +227,7 @@ public class ApptimizeFlutterPlugin implements FlutterPlugin, MethodCallHandler,
           break;
 
         case "getLibraryVersion":
-          String version = Apptimize.class.getPackage().getImplementationVersion();
+          String version = Apptimize.getVersion();
           resultValue = version + " (Android)";
           break;
 


### PR DESCRIPTION
3.7.18+ is basically equivalent to an exact 3.7.18. Ask for
3.10+ instead. Don't automatically move to 4.0; presumably that
will be breaking in some way and will need manual upgrade.

And ask for AAR explicitly, because 3.7.18 was the last .jar release
and aar isn't automatically looked for

Also: use Apptimize.getVersion (new in 3.10.4) instead of using
Apptimize.class.getPackage().getImplementationVersion()
(which returns 0.0). Not essential, but convenient to confirm
we're now getting the expected version.