### PR TITLE
RET-5573 Use https maven url for Android sdk dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+* Use a https maven URL for Android SDK dependency, for Gradle 7 support 
+
 ## 2.0.1
 
 * Fix ApptimizeVariable.declareXXX().value 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,6 @@ both Android and iOS flutter apps.
         apptimize_flutter: ^2.0.0    # Any 2.x version where x >= 0 works.
     ```
 
-    **Using the release from the official website**
-    * Download the latest SDK from the [SDK Download](https://apptimize.com/docs/sdk-information.html) page.
-    * Copy the SDK to a new directory outside of your project, such as apptimize_flutter.
-    * Reference the SDK in your pubspec.yaml as follows:
-        ```yml
-        dependencies:
-            apptimize_flutter:
-                path: ../apptimize_flutter/
-        ```
 2. Install it.
 
     * From the terminal: Run `flutter pub get`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
 rootProject.allprojects {
     repositories {
-        maven { url 'http://maven.apptimize.com/artifactory/repo' }
+        maven { url 'https://maven.apptimize.com/artifactory/repo' }
         google()
         jcenter()
     }

--- a/ios/apptimize_flutter.podspec
+++ b/ios/apptimize_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'apptimize_flutter'
-  s.version          = '2.0.1'
+  s.version          = '2.0.2'
   s.summary          = 'Apptimize SDK wrapper for iOS'
   s.description      = <<-DESC
   Apptimize SDK wrapper for iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptimize_flutter
 description: Apptimize Library for AB testing Flutter applications.
-version: 2.0.1
+version: 2.0.2
 homepage: https://www.apptimize.com
 repository: https://github.com/urbanairship/apptimize-flutter/
 


### PR DESCRIPTION
Because it just makes sense, and because apparently Gradle 7 demands it.

Also here:
- Don't reference a sdk download that doesn't exist in README
- Shorten pubspec.yaml description for an easy 10 points on the pub.dev score 
- Prep for releasing this as 2.0.2